### PR TITLE
Fix bug due to inconsistent format of OBS Locator log file header

### DIFF
--- a/ranging_survey_from_obsfile.py
+++ b/ranging_survey_from_obsfile.py
@@ -245,11 +245,17 @@ def read_obs_locator_log(filename):
     formats = [int, 'date', 'time', float, float, int, float, float, float]
 
     f = open(filename)
+    # TODO: Some versions of Discovery have '#' symbol at start of header line while others don't
     head = None
     while head is None:
         temp = f.readline()
-        if temp[0] != '#' and temp.strip():
-            head = re.split(r',|\s', temp.strip().lower())
+        if temp[0] == '#':
+            temp = temp[1:]
+        if temp.strip():
+            parts = re.split(r',|\s', temp.strip().lower())
+            if (parts[0] == 'address') and (len(parts) <= len(formats)):
+                # First field of range data is always modem address, should have same number of fields as list of value formats
+                head = parts[:]
     head.append('datetime')
 
     range_data = []

--- a/ranging_survey_from_obsfile.py
+++ b/ranging_survey_from_obsfile.py
@@ -243,24 +243,12 @@ def read_obs_locator_log(filename):
     import re
 
     formats = [int, 'date', 'time', float, float, int, float, float, float]
+    head = ['address', 'date', 'time', 'lat', 'lon', 'tat', 'range', 'depth', 'sos', 'datetime']
 
     f = open(filename)
-    # TODO: Some versions of Discovery have '#' symbol at start of header line while others don't
-    head = None
-    while head is None:
-        temp = f.readline()
-        if temp[0] == '#':
-            temp = temp[1:]
-        if temp.strip():
-            parts = re.split(r',|\s', temp.strip().lower())
-            if (parts[0] == 'address') and (len(parts) <= len(formats)):
-                # First field of range data is always modem address, should have same number of fields as list of value formats
-                head = parts[:]
-    head.append('datetime')
-
     range_data = []
     for line in f.readlines():
-        if line[0] == '#':
+        if line[0] == '#' or line[0] == 'A':
             continue
 
         parts = re.split(r',|\s', line.strip())

--- a/ranging_survey_from_obsfile.py
+++ b/ranging_survey_from_obsfile.py
@@ -248,7 +248,7 @@ def read_obs_locator_log(filename):
     f = open(filename)
     range_data = []
     for line in f.readlines():
-        if line[0] == '#' or line[0] == 'A':
+        if (line[0] == '#') or (line[0] == 'A') or (not line.strip()):
             continue
 
         parts = re.split(r',|\s', line.strip())


### PR DESCRIPTION
Some versions of Discovery include the "#" comment symbol at the start of the header line and some don't. We would prefer not to need to manually edit the log files before running the triangulation code, so need to handle both cases.